### PR TITLE
Don't use caret

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "date-now": "^0.1.4"
+    "date-now": "0.1.x"
   },
   "devDependencies": {
     "tape": "^2.12.3",


### PR DESCRIPTION
This is a dependency of `jshint` - I'm trying to use it on `node` `0.6`, and the `^` doesn't work on any `npm` that ships with `0.6`. It only matters for the dependency, not for the devDeps.

This is a necessary precursor to fixing https://github.com/arturadib/shelljs/pull/169