### PR TITLE
jspm Node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,12 @@
       "iphone/6.0..latest",
       "android-browser/4.2..latest"
     ]
+  },
+  "jspm": {
+    "map": {
+      "./index.js": {
+        "node": "@node/console"
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR includes the jspm configuration to allow `jspm install console=npm:console-browserify` to work both client and server by mapping to the Node core module in Node environments only.

No pressure - I completely understand if this isn't something you want to support, but it will simplify user configuration in jspm by managing this here.

Just let me know if you have any questions at all... still hope to change your previous opinion on jspm yet :)